### PR TITLE
EPMRPP-95905 || fix urls with trailing slash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
         implementation 'com.epam.reportportal:plugin-api'
         annotationProcessor 'com.epam.reportportal:plugin-api'
     } else {
-        implementation 'com.github.reportportal:commons-dao:11fa2a6'
+        implementation 'com.github.reportportal:commons-dao:562c5eb'
         implementation 'com.github.reportportal:plugin-api:8874441'
         annotationProcessor 'com.github.reportportal:plugin-api:8874441'
     }

--- a/src/main/java/com/epam/reportportal/extension/bugtracking/rally/RallyStrategy.java
+++ b/src/main/java/com/epam/reportportal/extension/bugtracking/rally/RallyStrategy.java
@@ -98,6 +98,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasypt.util.text.BasicTextEncryptor;
 import org.pf4j.Extension;
 import org.slf4j.Logger;
@@ -292,7 +293,8 @@ public class RallyStrategy implements ReportPortalExtensionPoint, BtsExtension {
 
   private Ticket toTicket(Defect defect, Integration externalSystem) {
     Ticket ticket = new Ticket();
-    String link = BtsConstants.URL.getParam(externalSystem.getParams(), String.class).get() + "/#/"
+    String baseUrl = StringUtils.removeEnd(BtsConstants.URL.getParam(externalSystem.getParams(), String.class).get(), "/");
+    String link =  baseUrl + "/#/"
         + Ref.getOidFromRef(defect.getProject().getRef()) + "/detail/defect/"
         + defect.getObjectId();
     ticket.setId(defect.getFormattedId());


### PR DESCRIPTION
Modified the `getClient` method to use `StringUtils.removeEnd` for better URL manipulation by removing trailing slashes. This ensures the base URL is correctly formatted before appending additional paths.